### PR TITLE
windows travis os에서 임시 제외

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 os:
   - "linux"
   - "osx"
-  - "windows"
+  # - "windows" # FIXME: 윈도우 빌드 속도가 개선될 때 다시 추가
 env:
   - GO111MODULE=on
 before_install:


### PR DESCRIPTION
Windows 쪽의 빌드가 오래 걸리는 상황(linux/mac: 3mins, windows: 12mins) 으로 속도가 개선될 때까지 제외